### PR TITLE
Fix Select2 Order

### DIFF
--- a/apps/artemis_web/lib/artemis_web/templates/layout/data_table_columns.html.eex
+++ b/apps/artemis_web/lib/artemis_web/templates/layout/data_table_columns.html.eex
@@ -1,7 +1,14 @@
 <%= form_for @conn, "", [class: "ui form data-table-columns"], fn f -> %>
-  <% selected = parse_data_table_requested_columns(@conn) %>
-  <% container_class = if length(selected) > 0, do: "active" %>
-  <div class="<%= container_class %>">
-    <%= multiple_select f, :columns, @available, selected: selected, class: "enhanced data-table-columns search", placeholder: "Custom Columns" %>
+  <div class="<%= @class %>">
+    <%=
+      multiple_select(
+        f,
+        :columns,
+        @available,
+        class: "enhanced data-table-columns search",
+        placeholder: "Custom Columns",
+        selected: @selected
+      )
+    %>
   </div>
 <% end %>

--- a/apps/artemis_web/lib/artemis_web/view_helpers/tables.ex
+++ b/apps/artemis_web/lib/artemis_web/view_helpers/tables.ex
@@ -21,7 +21,7 @@ defmodule ArtemisWeb.ViewHelper.Tables do
   def render_table_row_if_empty(_records, _options), do: nil
 
   @doc """
-  Render sortable table header 
+  Render sortable table header
   """
   def sortable_table_header(conn, value, label, delimiter \\ @default_delimiter) do
     path = order_path(conn, value, delimiter)
@@ -293,6 +293,24 @@ defmodule ArtemisWeb.ViewHelper.Tables do
   Render a select box to allow users to choose custom columns
   """
   def render_data_table_column_selector(conn, available_columns) do
-    Phoenix.View.render(ArtemisWeb.LayoutView, "data_table_columns.html", available: available_columns, conn: conn)
+    selected = parse_data_table_requested_columns(conn)
+    class = if length(selected) > 0, do: "active"
+
+    sorted_by_selected =
+      Enum.sort_by(available_columns, fn column ->
+        key = elem(column, 1)
+        index = Enum.find_index(selected, &(&1 == key)) || :infinity
+
+        index
+      end)
+
+    assigns = [
+      available: sorted_by_selected,
+      class: class,
+      conn: conn,
+      selected: selected
+    ]
+
+    Phoenix.View.render(ArtemisWeb.LayoutView, "data_table_columns.html", assigns)
   end
 end


### PR DESCRIPTION
Solves a problem with Select2 multi-select boxes where the order of items is not retained when the page reloads and instead are shown in alphabetical order.

This pull request fixes the issue by putting the selected values in the correct order at the beginning of the `<option>` list.